### PR TITLE
Ensure callbacks are always invoked on the right context

### DIFF
--- a/src/test/java/io/vertx/cassandra/CassandraServiceBase.java
+++ b/src/test/java/io/vertx/cassandra/CassandraServiceBase.java
@@ -18,6 +18,7 @@ package io.vertx.cassandra;
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.PreparedStatement;
 import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
@@ -52,8 +53,11 @@ public class CassandraServiceBase {
   private static final int BATCH_INSERT_SIZE = 1_000;
   private static final int TIMES_TO_INSERT_BATCH = 100;
 
+  private Context capturedContext = null;
+
   @Before
   public void before(TestContext context) throws IOException, TTransportException, InterruptedException {
+    capturedContext = null;
     EmbeddedCassandraServerHelper.startEmbeddedCassandra();
 
     Future<Void> namesKeyspaceInitialized = initializeNamesKeyspace();
@@ -130,6 +134,16 @@ public class CassandraServiceBase {
         .addContactPoint(HOST)
         .setPort(NATIVE_TRANSPORT_PORT)
     );
+  }
+
+  public synchronized void checkContext(TestContext testContext) {
+    if (capturedContext == null) {
+      capturedContext = vertx.getOrCreateContext();
+    } else if (!capturedContext.equals(vertx.getOrCreateContext())) {
+      testContext.fail("context is not the same");
+    }
+
+    capturedContext.exceptionHandler(testContext::fail);
   }
 
   @After

--- a/src/test/java/io/vertx/cassandra/ThreadingCheckTest.java
+++ b/src/test/java/io/vertx/cassandra/ThreadingCheckTest.java
@@ -1,0 +1,93 @@
+package io.vertx.cassandra;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Statement;
+import io.vertx.core.Future;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+/**
+ * This test suit is dedicated to check that all handler are called from the same context.
+ */
+@RunWith(VertxUnitRunner.class)
+public class ThreadingCheckTest extends CassandraServiceBase {
+
+  private static String NAME = "Pavel";
+
+  @Test
+  public void checkStreamHandlers(TestContext testContext) {
+    CassandraClient cassandraClient = CassandraClient.createNonShared(
+      vertx,
+      new CassandraClientOptions().setPort(NATIVE_TRANSPORT_PORT)
+    );
+    Async async = testContext.async(1);
+    Future<Void> future = Future.future();
+    cassandraClient.connect(future);
+    future.compose(connected -> {
+      checkContext(testContext);
+      Future<CassandraRowStream> queryResult = Future.future();
+      cassandraClient.queryStream("select random_string from random_strings.random_string_by_first_letter where first_letter = 'A'", queryResult);
+      return queryResult;
+    }).compose(stream -> {
+      checkContext(testContext);
+      stream.endHandler(end -> {
+        checkContext(testContext);
+        async.countDown();
+      })
+        .exceptionHandler(throwable -> checkContext(testContext))
+        .handler(item -> checkContext(testContext));
+      return Future.succeededFuture();
+    }).setHandler(h -> {
+      if (h.failed()) {
+        testContext.fail(h.cause());
+      }
+    });
+  }
+
+  @Test
+  public void checkConnectDisconnectPrepareAndQueryHandlers(TestContext testContext) {
+    CassandraClient cassandraClient = CassandraClient.createNonShared(
+      vertx,
+      new CassandraClientOptions().setPort(NATIVE_TRANSPORT_PORT)
+    );
+    Async async = testContext.async();
+    Future<Void> future = Future.future();
+    cassandraClient.connect(future);
+    future.compose(connected -> {
+      checkContext(testContext);
+      Future<PreparedStatement> queryResult = Future.future();
+      cassandraClient.prepare("INSERT INTO names.names_by_first_letter (first_letter, name) VALUES (?, ?)", queryResult);
+      return queryResult;
+    }).compose(prepared -> {
+      checkContext(testContext);
+      Future<ResultSet> executionQuery = Future.future();
+      Statement query = prepared.bind("P", "Pavel");
+      cassandraClient.execute(query, executionQuery);
+      return executionQuery;
+    }).compose(executed -> {
+      checkContext(testContext);
+      Future<List<Row>> executionQuery = Future.future();
+      cassandraClient.executeWithFullFetch("select NAME as n from names.names_by_first_letter where first_letter = 'P'", executionQuery);
+      return executionQuery;
+    }).compose(executed -> {
+      checkContext(testContext);
+      testContext.assertTrue(executed.get(0).getString("n").equals(NAME));
+      Future<Void> disconnectFuture = Future.future();
+      cassandraClient.disconnect(disconnectFuture);
+      return disconnectFuture;
+    }).setHandler(event -> {
+      checkContext(testContext);
+      if (event.failed()) {
+        testContext.fail(event.cause());
+      } else {
+        async.countDown();
+      }
+    });
+  }
+}


### PR DESCRIPTION
Using futures in Vert.x modules is tricky:
- there is no guarantee the module API will always be invoked on the same context (or even on a Vert.x thread)
- Future.setHandler callback is invoked on the caller thread if the future is already completed

Therefore it is safer to stick to callbacks.