### PR TITLE
Include of Rxified version example to the doc

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -124,3 +124,5 @@ In case you'd like to execute several queries at once, you can use https://docs.
 ----
 {@link examples.CassandraClientExamples#batching}
 ----
+
+include::override/rxjava.adoc[]

--- a/src/main/asciidoc/override/rxjava.adoc
+++ b/src/main/asciidoc/override/rxjava.adoc
@@ -1,0 +1,8 @@
+== RxJava API
+
+The Cassandra client provides an Rxified version of the original API.
+
+[source,java]
+----
+{@link examples.RxCassandraClientExamples#connectPrepareExecuteAndDisconnect(io.vertx.rxjava.cassandra.CassandraClient)}
+----


### PR DESCRIPTION
Related to "extra doc for vertx-rx" in https://github.com/vert-x3/vertx-cassandra-client/issues/11 and https://github.com/vert-x3/vertx-rx/pull/161