### PR TITLE
Add Cassandra object mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,21 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-mapping</artifactId>
+      <version>${datastax-driver.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -127,6 +127,15 @@ In case you'd like to execute several queries at once, you can use https://docs.
 {@link examples.CassandraClientExamples#batching}
 ----
 
+=== Object Mapper
+
+You can use the [Datastax object mapper](https://docs.datastax.com/en/developer/java-driver/latest/manual/object_mapper/) to map between domain classes and queries:
+
+[source, $lang]
+----
+{@link examples.CassandraClientExamples#mapper}
+----
+
 ifeval::["$lang" == "java"]
 include::override/rxjava2.adoc[]
 endif::[]

--- a/src/main/java/examples/CassandraClientExamples.java
+++ b/src/main/java/examples/CassandraClientExamples.java
@@ -19,13 +19,18 @@ import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
 import io.vertx.cassandra.CassandraClient;
 import io.vertx.cassandra.CassandraClientOptions;
 import io.vertx.cassandra.CassandraRowStream;
 import io.vertx.cassandra.ResultSet;
+import io.vertx.cassandra.VertxMapper;
+import io.vertx.cassandra.VertxMappingManager;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
 
+import java.util.Collections;
 import java.util.List;
 
 public class CassandraClientExamples {
@@ -191,5 +196,32 @@ public class CassandraClientExamples {
         result.cause().printStackTrace();
       }
     });
+  }
+
+  public void mapper(CassandraClient cassandraClient, Vertx vertx) {
+
+    // define class to use for database queries
+    @Table(keyspace = "test", name = "names")
+    class Test {
+      @PartitionKey private String name;
+
+      public Test(String name) {
+        this.name = name;
+      }
+    }
+
+    // define a mapper for the defined class
+    VertxMappingManager manager = VertxMappingManager.create(cassandraClient);
+    VertxMapper<Test> mapper = manager.mapper(Test.class, vertx);
+
+    // use mapper to get/save/delete objects
+    mapper.save(new Test("foo"), handler -> {
+      // handle result
+    });
+
+    mapper.save(new Test("foo"), handler -> {});
+    mapper.get(Collections.singletonList("foo"), handler -> {});
+    mapper.delete(Collections.singletonList("foo"), handler -> {});
+    mapper.delete(new Test("foo"), handler -> {});
   }
 }

--- a/src/main/java/io/vertx/cassandra/VertxMapper.java
+++ b/src/main/java/io/vertx/cassandra/VertxMapper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 The Vert.x Community.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.cassandra;
+
+import com.datastax.driver.mapping.Mapper;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+import java.util.List;
+
+/**
+ * A Vert.x wrapped datastax Mapper {@link com.datastax.driver.mapping.Mapper}.
+ *
+ * @author Martijn Zwennes
+ */
+@VertxGen
+public interface VertxMapper<T> {
+
+  /**
+   * @return the underlying datastax Mapper.
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Mapper<T> getMapper();
+
+  /**
+   * Asynchronous save method.
+   * @param entity object to be stored in database
+   * @param handler result handler
+   */
+  void save(T entity, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Asynchronous delete method.
+
+   * @param entity object to be deleted
+   * @param handler result handler
+   */
+  void delete(T entity, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Asynchronous delete method based on the primary key(s).
+   * @param primaryKeys primary key(s) used to find row(s) to delete
+   * @param handler result handler
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  void delete(List<Object> primaryKeys, Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Asynchronous get method.
+   * @param primaryKeys primary key(s) used to retrieve row(s)
+   * @param handler result handler
+   */
+  void get(List<Object> primaryKeys, Handler<AsyncResult<T>> handler);
+}

--- a/src/main/java/io/vertx/cassandra/VertxMappingManager.java
+++ b/src/main/java/io/vertx/cassandra/VertxMappingManager.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 The Vert.x Community.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.cassandra;
+
+import com.datastax.driver.mapping.MappingManager;
+import io.vertx.cassandra.impl.VertxMappingManagerImpl;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Vertx;
+
+/**
+ * A Vert.x wrapped datastax MappingManager {@link com.datastax.driver.mapping.MappingManager}.
+ *
+ * @author Martijn Zwennes
+ */
+@VertxGen
+public interface VertxMappingManager {
+
+  /**
+   * Create a VertxMappingManager from the given CassandraClient.
+   *
+   * @param client a Cassandra client instance
+   * @return a VertxMappingManager instance which is a wrapper for the datastax MappingManager
+   */
+  static VertxMappingManager create(CassandraClient client) {
+    return new VertxMappingManagerImpl(client);
+  }
+
+  /**
+   * @return the underlying datastax MappingManager.
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  MappingManager getMappingManager();
+
+  /**
+   * Returns a vert.x wrapped mapper which allows conversion
+   * of domain classes to and from query results.
+   *
+   * Example usage:
+   *
+   * {@literal @}Table(keyspace = "test", name = "users")
+   * class User {
+   *   {@literal @}PartitionKey String name;
+   *   ...
+   * }
+   *
+   * VertxMappingManager manager = cassandraClient.getMappingManager();
+   * VertxMapper<User> mapper = manager.mapper(User.class, vertx);
+   *
+   * mapper.save(new User("john", resultHandler));
+   *
+   * @param clazz class definition (e.g. User.class)
+   * @param vertx vertx instance
+   * @return a vert.x wrapped mapper for the given class
+   */
+  <T> VertxMapper<T> mapper(Class<T> clazz, Vertx vertx);
+}

--- a/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
@@ -24,6 +24,7 @@ import io.vertx.cassandra.ResultSet;
 import io.vertx.core.*;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.core.shareddata.Shareable;
+import io.vertx.cassandra.VertxMappingManager;
 
 import java.io.Closeable;
 import java.util.List;
@@ -241,13 +242,7 @@ public class CassandraClientImpl implements CassandraClient {
   public CassandraClient disconnect(Handler<AsyncResult<Void>> disconnectHandler) {
     Context context = vertx.getOrCreateContext();
     executeWithSession(session -> {
-      handleOnContext(session.closeAsync(), context, ar -> {
-        if (ar.succeeded()) {
-          disconnectHandler.handle(Future.succeededFuture());
-        } else {
-          disconnectHandler.handle(Future.failedFuture(ar.cause()));
-        }
-      });
+      handleOnContext(session.closeAsync(), context, disconnectHandler);
     }, disconnectHandler);
     return this;
   }
@@ -261,5 +256,9 @@ public class CassandraClientImpl implements CassandraClient {
         handlerToFailIfNoSessionPresent.handle(Future.failedFuture("In order to do this, you should be connected"));
       }
     }
+  }
+
+  Session getSession() {
+    return cassandraHolder.session.get();
   }
 }

--- a/src/main/java/io/vertx/cassandra/impl/Util.java
+++ b/src/main/java/io/vertx/cassandra/impl/Util.java
@@ -23,6 +23,8 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
+import java.util.Objects;
+
 /**
  * @author Pavel Drankou
  * @author Thomas Segismont
@@ -33,16 +35,20 @@ class Util {
    * Invokes the {@code handler} on a given {@code context} when the {@code listenableFuture} succeeds or fails.
    */
   static <T> void handleOnContext(ListenableFuture<T> listenableFuture, Context context, Handler<AsyncResult<T>> handler) {
-    Futures.addCallback(listenableFuture, new FutureCallback<T>() {
-      @Override
-      public void onSuccess(T result) {
-        context.runOnContext(v -> handler.handle(Future.succeededFuture(result)));
-      }
+    Objects.requireNonNull(listenableFuture, "listenableFuture must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+    if (handler != null) {
+      Futures.addCallback(listenableFuture, new FutureCallback<T>() {
+        @Override
+        public void onSuccess(T result) {
+          context.runOnContext(v -> handler.handle(Future.succeededFuture(result)));
+        }
 
-      @Override
-      public void onFailure(Throwable t) {
-        context.runOnContext(v -> Future.failedFuture(t));
-      }
-    });
+        @Override
+        public void onFailure(Throwable t) {
+          context.runOnContext(v -> handler.handle(Future.failedFuture(t)));
+        }
+      });
+    }
   }
 }

--- a/src/main/java/io/vertx/cassandra/impl/VertxMapperImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/VertxMapperImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 The Vert.x Community.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.cassandra.impl;
+
+import com.datastax.driver.mapping.Mapper;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.vertx.cassandra.VertxMapper;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+
+import java.util.List;
+
+/**
+ * @author Martijn Zwennes
+ */
+public class VertxMapperImpl<T> implements VertxMapper<T> {
+
+  private final Mapper<T> mapper;
+  private final Vertx vertx;
+
+  VertxMapperImpl(Mapper<T> mapper, Vertx vertx) {
+    this.mapper = mapper;
+    this.vertx = vertx;
+  }
+
+  @Override
+  public Mapper<T> getMapper() {
+    return mapper;
+  }
+
+  @Override
+  public void save(T entity, Handler<AsyncResult<Void>> handler) {
+    ListenableFuture<Void> futureSave = mapper.saveAsync(entity);
+    handle(futureSave, handler, vertx);
+  }
+
+  @Override
+  public void delete(T entity, Handler<AsyncResult<Void>> handler) {
+    ListenableFuture<Void> futureDelete = mapper.deleteAsync(entity);
+    handle(futureDelete, handler, vertx);
+  }
+
+  @Override
+  public void delete(List<Object> primaryKeys, Handler<AsyncResult<Void>> handler) {
+    ListenableFuture<Void> futureDelete = mapper.deleteAsync(primaryKeys.toArray());
+    handle(futureDelete, handler, vertx);
+  }
+
+  @Override
+  public void get(List<Object> primaryKeys, Handler<AsyncResult<T>> handler) {
+    ListenableFuture<T> futureGet = mapper.getAsync(primaryKeys.toArray());
+    handle(futureGet, handler, vertx);
+  }
+
+  private static <V> void handle(final ListenableFuture<V> future, Handler<AsyncResult<V>> handler, Vertx vertx) {
+    final Context context = vertx.getOrCreateContext();
+    Util.handleOnContext(future, context, handler);
+  }
+
+}

--- a/src/main/java/io/vertx/cassandra/impl/VertxMappingManagerImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/VertxMappingManagerImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 The Vert.x Community.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.cassandra.impl;
+
+import com.datastax.driver.mapping.Mapper;
+import com.datastax.driver.mapping.MappingManager;
+import io.vertx.cassandra.CassandraClient;
+import io.vertx.cassandra.VertxMapper;
+import io.vertx.cassandra.VertxMappingManager;
+import io.vertx.core.Vertx;
+
+/**
+ * @author Martijn Zwennes
+ */
+public class VertxMappingManagerImpl implements VertxMappingManager {
+
+  private final MappingManager mappingManager;
+
+  public VertxMappingManagerImpl(CassandraClient client) {
+    CassandraClientImpl clientImpl =  (CassandraClientImpl) client;
+    this.mappingManager = new MappingManager(clientImpl.getSession());
+  }
+
+  @Override
+  public MappingManager getMappingManager() {
+    return mappingManager;
+  }
+
+  @Override
+  public <T> VertxMapper<T> mapper(Class<T> clazz, Vertx vertx) {
+    Mapper<T> mapper = getMappingManager().mapper(clazz);
+    return new VertxMapperImpl<>(mapper, vertx);
+  }
+
+}

--- a/src/test/java/io/vertx/cassandra/CassandraServiceBase.java
+++ b/src/test/java/io/vertx/cassandra/CassandraServiceBase.java
@@ -120,6 +120,10 @@ public abstract class CassandraServiceBase {
       Future<ResultSet> createTable = Future.future();
       cassandraClient.execute("create table names.names_by_first_letter (first_letter text, name text, primary key (first_letter, name));", createTable);
       return createTable;
+    }).compose(keySpaceCreated -> {
+      Future<ResultSet> createTable = Future.future();
+      cassandraClient.execute("create table names.mapper_test (name text, age int, primary key (name));", createTable);
+      return createTable;
     }).compose(tableCreated -> {
       Future<Void> disconnectFuture = Future.future();
       cassandraClient.disconnect(disconnectFuture);

--- a/src/test/java/io/vertx/cassandra/MapperTest.java
+++ b/src/test/java/io/vertx/cassandra/MapperTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 The Vert.x Community.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.cassandra;
+
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import io.vertx.core.Future;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+
+@RunWith(VertxUnitRunner.class)
+public class MapperTest extends CassandraServiceBase {
+
+  @Test
+  public void mappingManagerInitialize(TestContext context) {
+    CassandraClient cassandraClient = CassandraClient.createNonShared(
+      vertx,
+      new CassandraClientOptions().setPort(NATIVE_TRANSPORT_PORT)
+    );
+
+    Async async = context.async();
+    cassandraClient.connect(connectEvent -> {
+      if (connectEvent.succeeded()) {
+        VertxMappingManager manager = VertxMappingManager.create(cassandraClient);
+        context.assertNotNull(manager);
+        async.complete();
+      }
+    });
+  }
+
+  @Test
+  public void initializeMapper(TestContext context) {
+    CassandraClient cassandraClient = CassandraClient.createNonShared(
+      vertx,
+      new CassandraClientOptions().setPort(NATIVE_TRANSPORT_PORT)
+    );
+
+    TestExample test = new TestExample("foo", 1);
+
+    // set handler for getting object using mapper
+    Async async = context.async();
+    Future<TestExample> getHandler = Future.future();
+    getHandler.setHandler(ar -> {
+      if (ar.succeeded()) {
+        context.assertEquals(test.name, ar.result().name);
+        context.assertEquals(test.age, ar.result().age);
+        async.complete();
+      } else {
+        context.fail("could not retrieve object from table");
+      }
+    });
+
+    // connect to Cassandra cluster and save/get an object
+    cassandraClient.connect(connectEvent -> {
+      if (connectEvent.succeeded()) {
+        VertxMappingManager manager = VertxMappingManager.create(cassandraClient);
+        VertxMapper<TestExample> mapper = manager.mapper(TestExample.class, vertx);
+        mapper.save(test, ar -> {
+          if (ar.succeeded()) {
+            mapper.get(Collections.singletonList("foo"), getHandler);
+          } else {
+            context.fail("could not save object to table");
+          }
+        });
+      } else {
+        context.fail("could not access cassandra database");
+      }
+    });
+
+  }
+
+  @Table(name = "mapper_test", keyspace = "names")
+  private static class TestExample {
+
+    @PartitionKey private String name;
+    private int age;
+
+    TestExample(String name, int age) {
+      this.name = name;
+      this.age = age;
+    }
+
+    TestExample() {}
+  }
+}

--- a/src/test/java/io/vertx/cassandra/impl/UtilTest.java
+++ b/src/test/java/io/vertx/cassandra/impl/UtilTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.cassandra.impl;
+
+import com.google.common.util.concurrent.AbstractFuture;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Executor;
+
+/**
+ * @author Thomas Segismont
+ */
+@RunWith(VertxUnitRunner.class)
+public class UtilTest {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+  @Test
+  public void testSuccess(TestContext testContext) {
+    Vertx vertx = rule.vertx();
+    SettableFuture<String> future = SettableFuture.create();
+    Context context = vertx.getOrCreateContext();
+    Util.handleOnContext(future, context, testContext.asyncAssertSuccess(value -> {
+      testContext.assertTrue(context == vertx.getOrCreateContext());
+      testContext.assertEquals("foo", value);
+    }));
+    future.set("foo");
+  }
+
+  @Test
+  public void testFailure(TestContext testContext) {
+    Vertx vertx = rule.vertx();
+    SettableFuture<String> future = SettableFuture.create();
+    Context context = vertx.getOrCreateContext();
+    Exception expected = new Exception();
+    Util.handleOnContext(future, context, testContext.asyncAssertFailure(throwable -> {
+      testContext.assertTrue(context == vertx.getOrCreateContext());
+      testContext.assertTrue(expected == throwable);
+    }));
+    future.setException(expected);
+  }
+
+  @Test
+  public void testNoHandler(TestContext testContext) {
+    Vertx vertx = rule.vertx();
+    ListenableFuture<Void> future = new AbstractFuture<Void>() {
+      @Override
+      public void addListener(Runnable listener, Executor executor) {
+        testContext.fail("No listener should be set");
+      }
+    };
+    Context context = vertx.getOrCreateContext();
+    Util.handleOnContext(future, context, null);
+  }
+}


### PR DESCRIPTION
This PR adds the datastax mapping manager to the `vertx-cassandra-client`.
Solves https://github.com/vert-x3/vertx-cassandra-client/issues/18

Example code:
```
@Table(keyspace = "test", name = "users")
class User {
  @PartitionKey String name;
  ..rest of POJO
}

VertxMappingManager manager = VertxMappingManager.create(cassandraClient);
VertxMapper<User> mapper = manager.mapper(User.class, vertx);

mapper.save(new User("john", hander -> {}));
```

Let me know how you guys feel about it.
