### PR TITLE
Fail tests on any java version other then 8

### DIFF
--- a/src/test/java/io/vertx/cassandra/CassandraClientTestBase.java
+++ b/src/test/java/io/vertx/cassandra/CassandraClientTestBase.java
@@ -57,6 +57,7 @@ public abstract class CassandraClientTestBase {
   @BeforeClass
   public static void startEmbeddedCassandra() throws Exception {
     String version = System.getProperty("java.version");
+    // this statement can be removed only when this issue[https://github.com/jsevellec/cassandra-unit/issues/249] will be resolved
     if (!version.startsWith("1.8")) {
       throw new IllegalStateException("Only Java 8 is allowed for running tests. Your java version: " + version);
     }

--- a/src/test/java/io/vertx/cassandra/CassandraClientTestBase.java
+++ b/src/test/java/io/vertx/cassandra/CassandraClientTestBase.java
@@ -16,7 +16,11 @@
 package io.vertx.cassandra;
 
 import com.datastax.driver.core.Row;
-import io.vertx.core.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.cassandraunit.CQLDataLoader;
@@ -52,6 +56,10 @@ public abstract class CassandraClientTestBase {
 
   @BeforeClass
   public static void startEmbeddedCassandra() throws Exception {
+    String version = System.getProperty("java.version");
+    if (!version.startsWith("1.8")) {
+      throw new IllegalStateException("Only Java 8 is allowed for running tests. Your java version: " + version);
+    }
     EmbeddedCassandraServerHelper.startEmbeddedCassandra();
   }
 


### PR DESCRIPTION
It took 10 minutes to figure out why tests are failing. Test running experience can be improved by throwing an error with instructions pointing out to switch JVM, so a contributor can instantly figure out. 