### PR TITLE
Add getExecutionInfo to ResultSet.

### DIFF
--- a/src/main/java/io/vertx/cassandra/ResultSet.java
+++ b/src/main/java/io/vertx/cassandra/ResultSet.java
@@ -133,9 +133,14 @@ public interface ResultSet {
   boolean wasApplied();
 
   /**
-   * @see com.datastax.driver.core.ResultSet#getExecutionInfo
+   * @see com.datastax.driver.core.PagingIterable#getExecutionInfo
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   ExecutionInfo getExecutionInfo();
   
+  /**
+   * @see com.datastax.driver.core.PagingIterable#getExecutionInfo
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  List<ExecutionInfo> getAllExecutionInfo();
 }

--- a/src/main/java/io/vertx/cassandra/impl/ResultSetImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/ResultSetImpl.java
@@ -191,4 +191,9 @@ public class ResultSetImpl implements ResultSet {
   public ExecutionInfo getExecutionInfo() {
     return resultSet.getExecutionInfo();
   }
+
+  @Override
+  public List<ExecutionInfo> getAllExecutionInfo() {
+    return resultSet.getAllExecutionInfo();
+  }
 }


### PR DESCRIPTION
The executionInfo would be nice to have for tracing and logging in certain cases. This is a straight passthrough to the underlying object.

I also noticed the build modifies the generated CassandraClientOptionsConverter. I didn't check in those changes, but I am happy to do so if that is desired.