### PR TITLE
Provide ResultSet access on CassandraRowStream

### DIFF
--- a/src/main/java/io/vertx/cassandra/CassandraRowStream.java
+++ b/src/main/java/io/vertx/cassandra/CassandraRowStream.java
@@ -15,6 +15,8 @@
  */
 package io.vertx.cassandra;
 
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.Row;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
@@ -65,9 +67,19 @@ public interface CassandraRowStream extends ReadStream<Row> {
   }
 
   /**
-   * Get the {@link ResultSet} this row stream is created from.
+   * Get the {@link ExectionInfo} provided by the backing {@link ResultSet} for this stream.
    *
-   * @returns the resultSet
+   * @returns the executionInfo
    */
-  ResultSet resultSet();
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  ExecutionInfo executionInfo();
+
+
+  /**
+   * Get the {@link ColumnDefinitions} provided by the backing {@link ResultSet} for this stream.
+   *
+   * @returns the columnDefinitions
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  ColumnDefinitions columnDefinitions();
 }

--- a/src/main/java/io/vertx/cassandra/CassandraRowStream.java
+++ b/src/main/java/io/vertx/cassandra/CassandraRowStream.java
@@ -63,4 +63,11 @@ public interface CassandraRowStream extends ReadStream<Row> {
   default void pipeTo(WriteStream<Row> dst, Handler<AsyncResult<Void>> handler) {
     ReadStream.super.pipeTo(dst, handler);
   }
+
+  /**
+   * Get the {@link ResultSet} this row stream is created from.
+   *
+   * @returns the resultSet
+   */
+  ResultSet resultSet();
 }

--- a/src/main/java/io/vertx/cassandra/impl/CassandraRowStreamImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/CassandraRowStreamImpl.java
@@ -119,6 +119,11 @@ public class CassandraRowStreamImpl implements CassandraRowStream {
     return this;
   }
 
+  @Override
+  public ResultSet resultSet() {
+    return this.resultSet;
+  }
+
   private synchronized void fetchRow() {
     if (state == State.STOPPED) {
       return;

--- a/src/main/java/io/vertx/cassandra/impl/CassandraRowStreamImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/CassandraRowStreamImpl.java
@@ -15,6 +15,8 @@
  */
 package io.vertx.cassandra.impl;
 
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.Row;
 import io.vertx.cassandra.CassandraRowStream;
 import io.vertx.cassandra.ResultSet;
@@ -120,8 +122,13 @@ public class CassandraRowStreamImpl implements CassandraRowStream {
   }
 
   @Override
-  public ResultSet resultSet() {
-    return this.resultSet;
+  public ExecutionInfo executionInfo() {
+    return resultSet.getExecutionInfo();
+  }
+
+  @Override
+  public ColumnDefinitions columnDefinitions(){
+    return resultSet.getColumnDefinitions();
   }
 
   private synchronized void fetchRow() {


### PR DESCRIPTION
Motivation:

The cassandra row stream is great. But when I try to log or add tracing metadata about the request, I can't access that metadata because the result set is encapsulated with no programmatic access.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
