### PR TITLE
Allow for preparing from SimpleStatement

### DIFF
--- a/src/main/java/io/vertx/cassandra/CassandraClient.java
+++ b/src/main/java/io/vertx/cassandra/CassandraClient.java
@@ -17,6 +17,7 @@ package io.vertx.cassandra;
 
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import io.vertx.cassandra.impl.CassandraClientImpl;
 import io.vertx.codegen.annotations.Fluent;
@@ -231,6 +232,24 @@ public interface CassandraClient {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Future<PreparedStatement> prepare(String query);
+
+  /**
+   * Prepares the provided a {@link SimpleStatement}.
+   *
+   * @param resultHandler handler called when result of query preparation is present
+   * @param statement the statement to prepare
+   *
+   * @return current Cassandra client instance
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  CassandraClient prepare(SimpleStatement statement, Handler<AsyncResult<PreparedStatement>> resultHandler);
+
+  /**
+   * Like {@link #prepare(SimpleStatement, Handler)} but returns a {@code Future} of the asynchronous result.
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<PreparedStatement> prepare(SimpleStatement statement);
 
   /**
    * Executes the given SQL <code>SELECT</code> statement which returns the results of the query as a read stream.

--- a/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
@@ -193,8 +193,7 @@ public class CassandraClientImpl implements CassandraClient {
   @Override
   public Future<PreparedStatement> prepare(SimpleStatement statement) {
     return getSession(vertx.getOrCreateContext())
-      .flatMap(
-        session -> Future.fromCompletionStage(session.prepareAsync(statement), vertx.getContext()));
+      .flatMap(session -> Future.fromCompletionStage(session.prepareAsync(statement), vertx.getContext()));
   }
 
   @Override

--- a/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
@@ -184,6 +184,20 @@ public class CassandraClientImpl implements CassandraClient {
   }
 
   @Override
+  public CassandraClient prepare(SimpleStatement statement, Handler<AsyncResult<PreparedStatement>> resultHandler) {
+    Future<PreparedStatement> future = prepare(statement);
+    setHandler(future, resultHandler);
+    return this;
+  }
+
+  @Override
+  public Future<PreparedStatement> prepare(SimpleStatement statement) {
+    return getSession(vertx.getOrCreateContext())
+      .flatMap(
+        session -> Future.fromCompletionStage(session.prepareAsync(statement), vertx.getContext()));
+  }
+
+  @Override
   public CassandraClient queryStream(String sql, Handler<AsyncResult<CassandraRowStream>> rowStreamHandler) {
     return queryStream(SimpleStatement.newInstance(sql), rowStreamHandler);
   }

--- a/src/test/java/io/vertx/cassandra/ExecutionTest.java
+++ b/src/test/java/io/vertx/cassandra/ExecutionTest.java
@@ -100,4 +100,19 @@ public class ExecutionTest extends CassandraClientTestBase {
       }));
     }));
   }
+
+  @Test
+  public void preparedStatementsShouldWorkWithSimpleStatement(TestContext testContext) {
+    initializeNamesKeyspace();
+    SimpleStatement insert = SimpleStatement.newInstance("INSERT INTO names.names_by_first_letter (first_letter, name) VALUES (?, ?)");
+    client.prepare(insert, testContext.asyncAssertSuccess(prepared -> {
+      BoundStatement statement = prepared.bind("P", "Pavel");
+      client.execute(statement, testContext.asyncAssertSuccess(exec -> {
+        String select = "select NAME as n from names.names_by_first_letter where first_letter = 'P'";
+        client.executeWithFullFetch(select, testContext.asyncAssertSuccess(rows -> {
+          testContext.assertTrue(rows.get(0).getString("n").equals("Pavel"));
+        }));
+      }));
+    }));
+  }
 }


### PR DESCRIPTION
Motivation:

Preparing via SimpleStatements allows for templating the prepared statement (IE query timeouts, etc).