### PR TITLE
Expose Metadata from the session.

### DIFF
--- a/src/main/java/io/vertx/cassandra/CassandraClient.java
+++ b/src/main/java/io/vertx/cassandra/CassandraClient.java
@@ -18,6 +18,7 @@ package io.vertx.cassandra;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
 import io.vertx.cassandra.impl.CassandraClientImpl;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
@@ -280,4 +281,10 @@ public interface CassandraClient {
    */
   @Fluent
   CassandraClient close(Handler<AsyncResult<Void>> closeHandler);
+
+  /**
+   * Get {@link Metadata} for the session.
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<Metadata> getMetadata();
 }

--- a/src/main/java/io/vertx/cassandra/CassandraClient.java
+++ b/src/main/java/io/vertx/cassandra/CassandraClient.java
@@ -286,5 +286,5 @@ public interface CassandraClient {
    * Get {@link Metadata} for the session.
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  Future<Metadata> getMetadata();
+  Future<Metadata> metadata();
 }

--- a/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
@@ -243,7 +243,7 @@ public class CassandraClientImpl implements CassandraClient {
   }
 
   @Override
-  public Future<Metadata> getMetadata() {
+  public Future<Metadata> metadata() {
     return getSession(vertx.getOrCreateContext()).map(Session::getMetadata);
   }
 

--- a/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/CassandraClientImpl.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
 import com.datastax.oss.driver.api.core.session.Session;
 import io.vertx.cassandra.CassandraClient;
 import io.vertx.cassandra.CassandraClientOptions;
@@ -239,6 +240,11 @@ public class CassandraClientImpl implements CassandraClient {
     Future<Void> future = close();
     setHandler(future, closeHandler);
     return this;
+  }
+
+  @Override
+  public Future<Metadata> getMetadata() {
+    return getSession(vertx.getOrCreateContext()).map(Session::getMetadata);
   }
 
   private synchronized boolean raiseCloseFlag() {


### PR DESCRIPTION
Motivation:

There are a number of use cases that make accessing the metadata on the session useful. In my case, accessing UserDefinedTypes so they can be cached for use in decoding rows without having to resort to creating those objects on every request.
