### PR TITLE
Add copy constructor

### DIFF
--- a/src/main/java/io/vertx/cassandra/CassandraClientOptions.java
+++ b/src/main/java/io/vertx/cassandra/CassandraClientOptions.java
@@ -53,6 +53,15 @@ public class CassandraClientOptions {
   }
 
   /**
+   * Copy constructor.
+   * @param other The other client to copy from.
+   */
+  public CassandraClientOptions(CassandraClientOptions other) {
+    this(other.dataStaxClusterBuilder());
+    this.setKeyspace(other.getKeyspace());
+  }
+
+  /**
    * Constructor using an existing {@link CqlSessionBuilder} instance.
    */
   public CassandraClientOptions(CqlSessionBuilder builder) {


### PR DESCRIPTION
In the old versions of the client, we had the copy constructor for options. I think we should also have it for the current versions.

Closes #53. 