### PR TITLE
Call handleEnd and fetchRow always with runOnContext

### DIFF
--- a/src/main/java/io/vertx/cassandra/impl/CassandraRowStreamImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/CassandraRowStreamImpl.java
@@ -64,26 +64,19 @@ public class CassandraRowStreamImpl implements CassandraRowStream {
 
   @Override
   public synchronized CassandraRowStream handler(Handler<Row> handler) {
+    Context ctx = context != Vertx.currentContext() ? context : Vertx.currentContext();
     if (state == State.STOPPED) {
       return this;
     }
     if (handler == null) {
       stop();
-      if (context != Vertx.currentContext()) {
-        context.runOnContext(v -> handleEnd());
-      } else {
-        handleEnd();
-      }
+      ctx.runOnContext(v -> handleEnd());
     } else {
       this.handler = handler;
       internalQueue.handler(this::handleRow);
       if (state == State.IDLE) {
         state = State.STARTED;
-        if (context != Vertx.currentContext()) {
-          context.runOnContext(v -> fetchRow());
-        } else {
-          fetchRow();
-        }
+        ctx.runOnContext(v -> fetchRow());
       }
     }
     return this;

--- a/src/main/java/io/vertx/cassandra/impl/CassandraRowStreamImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/CassandraRowStreamImpl.java
@@ -64,19 +64,18 @@ public class CassandraRowStreamImpl implements CassandraRowStream {
 
   @Override
   public synchronized CassandraRowStream handler(Handler<Row> handler) {
-    Context ctx = context != Vertx.currentContext() ? context : Vertx.currentContext();
     if (state == State.STOPPED) {
       return this;
     }
     if (handler == null) {
       stop();
-      ctx.runOnContext(v -> handleEnd());
+      context.runOnContext(v -> handleEnd());
     } else {
       this.handler = handler;
       internalQueue.handler(this::handleRow);
       if (state == State.IDLE) {
         state = State.STARTED;
-        ctx.runOnContext(v -> fetchRow());
+        context.runOnContext(v -> fetchRow());
       }
     }
     return this;

--- a/src/test/java/io/vertx/cassandra/StreamingTest.java
+++ b/src/test/java/io/vertx/cassandra/StreamingTest.java
@@ -98,4 +98,18 @@ public class StreamingTest extends CassandraClientTestBase {
         .handler(item -> testContext.fail());
     }));
   }
+
+  @Test
+  public void emptyStreamWithHandlerSetFirst(TestContext testContext) throws Exception {
+    initializeRandomStringKeyspace();
+    insertRandomStrings(1);
+    String query = "select random_string from random_strings.random_string_by_first_letter where first_letter = '$'";
+    Async async = testContext.async();
+    client.queryStream(query, testContext.asyncAssertSuccess(stream -> {
+        stream.handler(item -> testContext.fail())
+          .endHandler(end -> async.countDown())
+          .exceptionHandler(testContext::fail);
+      })
+    );
+  }
 }


### PR DESCRIPTION
That is why we need it by @tsegismont:

> If we always invoke runOnContext then the endHandler will be set before the client attempts to fetch any row.

Closes #61 

