### PR TITLE
Bump Datastax driver version: 4.2.2 -> 4.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <!--
     Update these properties in the vertx-lang-* modules too
      -->
-    <datastax-driver.version>4.2.2</datastax-driver.version>
+    <datastax-driver.version>4.9.0</datastax-driver.version>
     <junit.version>4.12</junit.version>
     <slf4j.version>1.7.21</slf4j.version>
     <guava.version>25.1-jre</guava.version>


### PR DESCRIPTION
Updating  Datastax driver to the most recent version.

Closes #51 