### PR TITLE
Upgrade DataStax Java Driver from 4.11.0 to 4.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <!--
     Update these properties in the vertx-lang-* modules too
      -->
-    <datastax-driver.version>4.11.0</datastax-driver.version>
+    <datastax-driver.version>4.11.1</datastax-driver.version>
     <junit.version>4.13.1</junit.version>
     <slf4j.version>1.7.21</slf4j.version>
     <testcontainers.version>1.15.2</testcontainers.version>


### PR DESCRIPTION
Motivation:

`4.11.1` addresses a critical bug related to the upcoming Cassandra 4.0 release and aids in testing the release candidates that are available today.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
