### PR TITLE
Add username/password to CassandraClientOptions

### DIFF
--- a/src/main/generated/io/vertx/cassandra/CassandraClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/cassandra/CassandraClientOptionsConverter.java
@@ -29,6 +29,16 @@ public class CassandraClientOptionsConverter {
             obj.setKeyspace((String)member.getValue());
           }
           break;
+        case "password":
+          if (member.getValue() instanceof String) {
+            obj.setPassword((String)member.getValue());
+          }
+          break;
+        case "username":
+          if (member.getValue() instanceof String) {
+            obj.setUsername((String)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -40,6 +50,12 @@ public class CassandraClientOptionsConverter {
   public static void toJson(CassandraClientOptions obj, java.util.Map<String, Object> json) {
     if (obj.getKeyspace() != null) {
       json.put("keyspace", obj.getKeyspace());
+    }
+    if (obj.getPassword() != null) {
+      json.put("password", obj.getPassword());
+    }
+    if (obj.getUsername() != null) {
+      json.put("username", obj.getUsername());
     }
   }
 }

--- a/src/main/java/io/vertx/cassandra/CassandraClientOptions.java
+++ b/src/main/java/io/vertx/cassandra/CassandraClientOptions.java
@@ -21,7 +21,6 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
 import java.net.InetSocketAddress;
-import java.util.List;
 
 /**
  * Eclipse Vert.x Cassandra client options.
@@ -42,8 +41,11 @@ public class CassandraClientOptions {
    */
   public static final String DEFAULT_HOST = "localhost";
 
-  private CqlSessionBuilder builder;
+  private final CqlSessionBuilder builder;
+
   private String keyspace;
+  private String username;
+  private String password;
 
   /**
    * Default constructor.
@@ -134,6 +136,52 @@ public class CassandraClientOptions {
   public CassandraClientOptions setKeyspace(String keyspace) {
     this.keyspace = keyspace;
     builder.withKeyspace(keyspace);
+    return this;
+  }
+
+  /**
+   * @return the username if plaintext authentication is used
+   */
+  public String getUsername() {
+    return username;
+  }
+
+  /**
+   * Set the username for plaintext authentication. Defaults to {@code null}.
+   *
+   * @param username the username for plaintext authentication
+   * @return a reference to this, so the API can be used fluently
+   */
+  public CassandraClientOptions setUsername(String username) {
+    this.username = username;
+    setAuth();
+    return this;
+  }
+
+  private void setAuth() {
+    if (username == null || password == null) {
+      builder.withAuthProvider(null);
+    } else {
+      builder.withAuthCredentials(username, password);
+    }
+  }
+
+  /**
+   * @return the password if plaintext authentication is used
+   */
+  public String getPassword() {
+    return password;
+  }
+
+  /**
+   * Set the password for plaintext authentication. Defaults to {@code null}.
+   *
+   * @param password the username for plaintext authentication
+   * @return a reference to this, so the API can be used fluently
+   */
+  public CassandraClientOptions setPassword(String password) {
+    this.password = password;
+    setAuth();
     return this;
   }
 }

--- a/src/test/java/io/vertx/cassandra/AuthenticationTest.java
+++ b/src/test/java/io/vertx/cassandra/AuthenticationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.cassandra;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(VertxUnitRunner.class)
+public class AuthenticationTest {
+
+  private static final int CQL_PORT = 9042;
+
+  @Rule
+  public RunTestOnContext vertx = new RunTestOnContext();
+
+  @Rule
+  public GenericContainer<?> authContainer = new GenericContainer<>(
+    new ImageFromDockerfile()
+      .withFileFromClasspath("Dockerfile", "auth-container/Dockerfile")
+  )
+    .waitingFor(Wait.forLogMessage(".*Created default superuser role 'cassandra'.*\\n", 1))
+    .withExposedPorts(CQL_PORT);
+
+  private CassandraClient client;
+
+  @Test
+  public void testAuthProvider(TestContext context) {
+    CassandraClientOptions options = new CassandraClientOptions()
+      .addContactPoint("localhost", authContainer.getMappedPort(CQL_PORT))
+      .setUsername("cassandra")
+      .setPassword("cassandra");
+    options.dataStaxClusterBuilder().withLocalDatacenter("datacenter1");
+    client = CassandraClient.createShared(vertx.vertx(), options);
+    client.executeWithFullFetch("select release_version from system.local", context.asyncAssertSuccess(result -> {
+      context.verify(unused -> {
+        assertThat(result.iterator().next().getString("release_version"), startsWith("3.11"));
+      });
+    }));
+  }
+
+  @After
+  public void tearDown(TestContext context) {
+    if (client != null) {
+      client.close(context.asyncAssertSuccess());
+    }
+  }
+}

--- a/src/test/resources/auth-container/Dockerfile
+++ b/src/test/resources/auth-container/Dockerfile
@@ -1,0 +1,3 @@
+FROM cassandra:3.11
+
+RUN echo "authenticator: PasswordAuthenticator" >> /etc/cassandra/cassandra.yaml


### PR DESCRIPTION
Closes #31

Previously, username and password needed to be set through the underlying `SessionBuilder`.
But changing username/password is a common use case that can be simplified with this change.