### PR TITLE
#77 - fix mac os test fail

### DIFF
--- a/src/test/java/io/vertx/cassandra/AuthenticationTest.java
+++ b/src/test/java/io/vertx/cassandra/AuthenticationTest.java
@@ -20,6 +20,8 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +49,12 @@ public class AuthenticationTest {
     .withExposedPorts(CQL_PORT);
 
   private CassandraClient client;
+
+  @BeforeClass
+  public static void notMacOs(){
+    Assume.assumeFalse("Test is running on a non mac os machine",
+      System.getProperty("os.name").equals("Mac OS X"));
+  }
 
   @Test
   public void testAuthProvider(TestContext context) {

--- a/src/test/java/io/vertx/cassandra/AuthenticationTest.java
+++ b/src/test/java/io/vertx/cassandra/AuthenticationTest.java
@@ -52,8 +52,7 @@ public class AuthenticationTest {
 
   @BeforeClass
   public static void notMacOs(){
-    Assume.assumeFalse("Test is running on a non mac os machine",
-      System.getProperty("os.name").equals("Mac OS X"));
+    Assume.assumeFalse("Test does not work on a Mac OS", io.netty.util.internal.PlatformDependent.isOsx());
   }
 
   @Test


### PR DESCRIPTION
Auth test is being ignored on mac os because of some strange testcontainers behaviour on mac os: created auth container affects the main test container 

Fixes #77
