### PR TITLE
Datastax driver version bump 4.11 -> 4.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <!--
     Update these properties in the vertx-lang-* modules too
      -->
-    <datastax-driver.version>4.11.1</datastax-driver.version>
+    <datastax-driver.version>4.15.0</datastax-driver.version>
     <junit.version>4.13.1</junit.version>
     <slf4j.version>1.7.21</slf4j.version>
     <testcontainers.version>1.15.2</testcontainers.version>


### PR DESCRIPTION
Updating Datastax driver to the most recent version.

Closes https://github.com/vert-x3/vertx-cassandra-client/issues/79