### PR TITLE
Fix TracingTest failures

### DIFF
--- a/src/test/java/io/vertx/cassandra/tests/TracingTest.java
+++ b/src/test/java/io/vertx/cassandra/tests/TracingTest.java
@@ -91,9 +91,11 @@ public class TracingTest extends CassandraClientTestBase {
       }
     };
 
-    client.executeWithFullFetch(cql).onComplete(ctx.asyncAssertSuccess(rows -> {
-      async.countDown();
-    }));
+    expectedContext.runOnContext(v -> {
+      client.executeWithFullFetch(cql).onComplete(ctx.asyncAssertSuccess(rows -> {
+        async.countDown();
+      }));
+    });
   }
 
   @Test
@@ -126,7 +128,9 @@ public class TracingTest extends CassandraClientTestBase {
       }
     };
 
-    client.executeWithFullFetch(cql).onComplete(ctx.asyncAssertFailure(t -> async.countDown()));
+    expectedContext.runOnContext(v -> {
+      client.executeWithFullFetch(cql).onComplete(ctx.asyncAssertFailure(t -> async.countDown()));
+    });
   }
 
   @Test
@@ -161,11 +165,12 @@ public class TracingTest extends CassandraClientTestBase {
       }
     };
 
-    client.prepare(cql).onComplete(ctx.asyncAssertSuccess(ps -> {
-      client.execute(ps.bind("B")).onComplete(ctx.asyncAssertSuccess(rs -> {
-        async.countDown();
+    expectedContext.runOnContext(v -> {
+      client.prepare(cql).onComplete(ctx.asyncAssertSuccess(ps -> {
+        client.execute(ps.bind("B")).onComplete(ctx.asyncAssertSuccess(rs -> {
+          async.countDown();
+        }));
       }));
-    }));
-
+    });
   }
 }


### PR DESCRIPTION
This follows-up on sticky context removal in Vert.x core.