### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,16 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/src/main/java/io/vertx/cassandra/CassandraRowStream.java
+++ b/src/main/java/io/vertx/cassandra/CassandraRowStream.java
@@ -20,7 +20,6 @@ import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.Row;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.streams.ReadStream;

--- a/src/main/java/io/vertx/cassandra/impl/ResultSetImpl.java
+++ b/src/main/java/io/vertx/cassandra/impl/ResultSetImpl.java
@@ -20,7 +20,6 @@ import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.Row;
 import io.vertx.cassandra.ResultSet;
 import io.vertx.core.*;
-import io.vertx.core.internal.ContextInternal;
 
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.